### PR TITLE
Refactoring to use ConfigureHttpClient

### DIFF
--- a/HttpClientSample/Framework/ServiceCollectionExtensions.cs
+++ b/HttpClientSample/Framework/ServiceCollectionExtensions.cs
@@ -51,16 +51,15 @@
                 .Configure<TClientOptions>(configuration.GetSection(configurationSectionName))
                 .AddTransient<CorrelationIdDelegatingHandler>()
                 .AddTransient<UserAgentDelegatingHandler>()
-                .AddHttpClient<TClient, TImplementation>(
-                    options =>
-                    {
-                        var httpClientOptions = services
-                            .BuildServiceProvider()
-                            .GetRequiredService<IOptions<TClientOptions>>()
-                            .Value;
-                        options.BaseAddress = httpClientOptions.BaseAddress;
-                        options.Timeout = httpClientOptions.Timeout;
-                    })
+                .AddHttpClient<TClient, TImplementation>()
+                .ConfigureHttpClient((sp, options) =>
+                {
+                    var httpClientOptions = sp
+                        .GetRequiredService<IOptions<TClientOptions>>()
+                        .Value;
+                    options.BaseAddress = httpClientOptions.BaseAddress;
+                    options.Timeout = httpClientOptions.Timeout;
+                })
                 .ConfigurePrimaryHttpMessageHandler(x => new DefaultHttpClientHandler())
                 .AddPolicyHandlerFromRegistry(PolicyName.HttpRetry)
                 .AddPolicyHandlerFromRegistry(PolicyName.HttpCircuitBreaker)


### PR DESCRIPTION
A small change which should be more efficient as the ConfigureHttpClient method allows you to use the current service provider rather than having to build one each time a HttpClient is built.